### PR TITLE
Prevent exception when notification array not specified

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,8 @@ const passport = require('passport');
 const mqtt = require('mqtt');
 /* */
 const config = require('./config');
-config.notification= config.notification||[];
+config.notification = config.notification || [];
+
 const Device = require('./device');
 
 /* */

--- a/app.js
+++ b/app.js
@@ -20,6 +20,7 @@ const passport = require('passport');
 const mqtt = require('mqtt');
 /* */
 const config = require('./config');
+config.notification= config.notification||[];
 const Device = require('./device');
 
 /* */


### PR DESCRIPTION
There is an exception thrown when trying to use Yandex Notification API if there are no notification in config file. 
Added empty array to prevent exception.